### PR TITLE
Changes to make the s3 wagon work on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
-    </dependencies>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.9.16</version>
+        </dependency>
+     </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
- Pulled in javax.xml.bind explicitly (it was removed from the default
  libraries in java 11).
- Pull in bytebuddy 1.9.16 explicitly (without this a unit test was failing
  because the bytebuddy pulled in by default was too old to work properly
  with junit).